### PR TITLE
Fix compatibility with nvcc & programs working without CUDA

### DIFF
--- a/include/ckl/kernel_loader.h
+++ b/include/ckl/kernel_loader.h
@@ -7,15 +7,9 @@
 #include <vector>
 #include <regex>
 #include <memory>
+#include <spdlog/fwd.h>
 
 #include "common.h"
-
-namespace spdlog {
-class logger;
-namespace level {
-enum level_enum : int;
-}
-}
 
 CKL_NAMESPACE_BEGIN
 

--- a/include/ckl/kernel_loader.h
+++ b/include/ckl/kernel_loader.h
@@ -7,9 +7,15 @@
 #include <vector>
 #include <regex>
 #include <memory>
-#include <spdlog/spdlog.h>
 
 #include "common.h"
+
+namespace spdlog {
+class logger;
+namespace level {
+enum level_enum : int;
+}
+}
 
 CKL_NAMESPACE_BEGIN
 

--- a/src/kernel_loader.cpp
+++ b/src/kernel_loader.cpp
@@ -6,6 +6,7 @@
 #include <fstream>
 #include <mutex>
 #include <thread>
+#include <spdlog/spdlog.h>
 #include "spdlog/sinks/stdout_color_sinks.h"
 
 #include "sha1.h"
@@ -409,7 +410,11 @@ KernelLoader::KernelLoader(std::shared_ptr<spdlog::logger> logger)
 {
     //query compute capability
     cudaDeviceProp props {0};
-    CKL_SAFE_CALL(cudaGetDeviceProperties(&props, 0));
+    auto retVal = cudaGetDeviceProperties(&props, 0);
+    if (retVal == cudaErrorInsufficientDriver) {
+        return;
+    }
+    CKL_SAFE_CALL(retVal);
     computeMajor_ = props.major;
     computeMinor_ = props.minor;
     logger_->info("Compiling kernels for device '{}' with compute capability {}.{}",


### PR DESCRIPTION
Moved spdlog include to source file. Added check for return value of CUDA call in KernelLoader constructor to avoid errors on startup of programs linking to this library when CUDA is not available.