### PR TITLE
Added function for early deletion of instance & new error code check

### DIFF
--- a/include/ckl/kernel_loader.h
+++ b/include/ckl/kernel_loader.h
@@ -338,9 +338,14 @@ public:
     void checkCudaAvailable() const;
 
     /**
-     * The global singleton instance
+     * Returns the global singleton instance
      */
     static KernelLoader& Instance();
+
+    /**
+     * Deletes the global singleton instance
+     */
+    static void DeleteInstance();
 
     /**
      * Returns the logger instance used to report compile logs (debug) or errors
@@ -477,6 +482,8 @@ public:
     [[nodiscard]] int computeCapability() const { return computeMajor_; }
 
 private:
+
+    static std::unique_ptr<KernelLoader> INSTANCE;
 
     //Loads the CUDA source file
     //Returns true if the source files have changed


### PR DESCRIPTION
This PR adds a new function for early deletion of the KernelLoader instance. This is necessary for programs managing their own CUDA context using the driver API, which will most likely no longer be valid at program termination when the global instance is deleted. Also, another CUDA error code is added that should not lead to program termination at startup.
